### PR TITLE
Added Capture Images Function

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -8,9 +8,10 @@ SREND = 1
 SRSTEP = 2
 SRTIME = 3
 SRIMAGE = 4
-SRPOSE = 5
-SRWHEELS = 6
-SRENABLED = 7
+SRMANYIMAGES = 5
+SRPOSE = 6
+SRWHEELS = 7
+SRENABLED = 8
 
 class SimConfig:
     def __init__(self, bin_configuration_yaml):
@@ -81,6 +82,8 @@ def _sim_server(q, s, sim_config):
             elif req_token[0] == SRENABLED:
                 g.mobile_agent.enabled = req_token[1]
                 s.put(g.mobile_agent.enabled)
+            elif req_token[0] == SRMANYIMAGES:
+                s.put(g.mobile_agent.capture_images(req_token[1]))
         elif req_token == SRRESET:
             s.put(g.reset())
         elif req_token == SREND:
@@ -131,6 +134,9 @@ def set_time(time):
 
 def read_robot_cam():
     return request(SRIMAGE)
+
+def get_simulated_images(poses):
+    return request((SRMANYIMAGES, poses))
 
 def get_robot_pose():
     return request(SRPOSE)

--- a/simulator/blockstacker_agent.py
+++ b/simulator/blockstacker_agent.py
@@ -136,7 +136,7 @@ class BlockStackerAgent:
           renderer=p.ER_BULLET_HARDWARE_OPENGL
         )[2]
 
-    def capture_images(self, poses):
+    def capture_images(self, poses, MAKE_TRANSPARENT_BEFORE=True, MAKE_VISIBLE_AFTER=True):
         # The threshold at which objects become invisible for this method
         # Is a weird non-linear function:
         #   trueDepth = far * near / (far - (far-near) * this_value)
@@ -144,6 +144,15 @@ class BlockStackerAgent:
         #   match observation
         # Set it to a value close to one
         DEPTH_MASK = .99
+
+        # If we need to, make outselves transparent
+        # Store the old colors for later
+        old_colors = {}
+        if MAKE_TRANSPARENT_BEFORE:
+            temp = p.getVisualShapeData(self.robot)
+            for ji in range(-1, p.getNumJoints(self.robot)):
+                old_colors[ji] = temp[ji+1][7]
+                p.changeVisualShape(self.robot, ji, rgbaColor=[0,0,0,0])
 
         ret = []
         for po in poses:
@@ -163,6 +172,11 @@ class BlockStackerAgent:
             np.place(img[:,:,3], depth>DEPTH_MASK, 0)
             # Return
             ret.append(img)
+
+        # Make ourselves visible again if we need to
+        if MAKE_VISIBLE_AFTER:
+            for ji, color in old_colors.items():
+                p.changeVisualShape(self.robot, ji, rgbaColor=color)
 
         return ret
 

--- a/simulator/blockstacker_agent.py
+++ b/simulator/blockstacker_agent.py
@@ -15,6 +15,7 @@ from simulator.differentialdrive import DifferentialDrive
 from simulator.utilities import Utilities
 
 COM_TO_SIP = .174676
+COM_TO_AXE = .074676
 # We center the camera on the y-axis
 # Old offset was [.0807,.0324,.06624]
 CAM_OFFSET_VEC = [.0807,0,.06624]
@@ -88,8 +89,9 @@ class BlockStackerAgent:
         
     def __posort_to_pose__(self, pos, ort):
         # Just use a utility method to extrapolate the SIP
-        p_pos = p.multiplyTransforms(pos, ort, [0,COM_TO_SIP,0], [0,0,0,1])[0]
-        p_theta = atan2(p_pos[1]-pos[1], p_pos[0]-pos[0])
+        p_pos = p.multiplyTransforms(pos, ort, [0,COM_TO_SIP,0], [0,0,0,1])[0][0:2]
+        a_pos = p.multiplyTransforms(pos, ort, [0,COM_TO_AXE,0], [0,0,0,1])[0][0:2]
+        p_theta = atan2(p_pos[1]-a_pos[1], p_pos[0]-a_pos[0])
         return (*p_pos, p_theta)
 
     def get_pose(self, NOISE_POS=.02, NOISE_ANG=10):

--- a/simulator/blockstacker_agent.py
+++ b/simulator/blockstacker_agent.py
@@ -15,7 +15,9 @@ from simulator.differentialdrive import DifferentialDrive
 from simulator.utilities import Utilities
 
 COM_TO_SIP = .174676
-CAM_OFFSET_VEC = [.0807,.0324,.06624]
+# We center the camera on the y-axis
+# Old offset was [.0807,.0324,.06624]
+CAM_OFFSET_VEC = [.0807,0,.06624]
 
 class BlockStackerAgent:
     """The BlockStackerAgent class maintains the blockstacker agent"""

--- a/simulator/blockstacker_agent.py
+++ b/simulator/blockstacker_agent.py
@@ -40,12 +40,12 @@ class BlockStackerAgent:
         self.blink_count = 0
 
         self.camera_projection_matrix = p.computeProjectionMatrixFOV(
-          fov=45.0,
-          aspect=1.0,
+          fov=62.2,
+          aspect=16/9,
           nearVal=0.1,
           farVal=3.1)
-        self.camera_h_res = 300
-        self.camera_v_res = 300
+        self.camera_h_res = 640
+        self.camera_v_res = 360
         self.camera_focal_len = .1
 
     def load_urdf(self):

--- a/simulator/blockstacker_agent.py
+++ b/simulator/blockstacker_agent.py
@@ -16,9 +16,9 @@ from simulator.utilities import Utilities
 
 COM_TO_SIP = .174676
 COM_TO_AXE = .074676
-# We center the camera on the y-axis
+# We center the camera on the x-axis
 # Old offset was [.0807,.0324,.06624]
-CAM_OFFSET_VEC = [.0807,0,.06624]
+CAM_OFFSET_VEC = [0,.0324,.06624]
 
 class BlockStackerAgent:
     """The BlockStackerAgent class maintains the blockstacker agent"""

--- a/simulator/game.py
+++ b/simulator/game.py
@@ -155,6 +155,8 @@ class Game:
 
         self.info_id = Utilities.draw_debug_info(self.time)
 
+        self.mobile_agent.set_pose([-.9,0,0])
+
     def reset(self):
         p.restoreState(self.starting_state)
         self.time = self.starting_time

--- a/simulator/game.py
+++ b/simulator/game.py
@@ -155,8 +155,6 @@ class Game:
 
         self.info_id = Utilities.draw_debug_info(self.time)
 
-        self.mobile_agent.set_pose([-.9,0,0])
-
     def reset(self):
         p.restoreState(self.starting_state)
         self.time = self.starting_time

--- a/simulator/game.py
+++ b/simulator/game.py
@@ -8,6 +8,7 @@ Last Modified: Binit on 2/15
 import os
 import time
 import pybullet as p
+from PIL import Image
 
 from simulator.field import Field
 from simulator.legos import Legos
@@ -200,3 +201,6 @@ class Game:
         # self.monitor_buttons()
         self.legos.step(self.mobile_agent.robot, self.mobile_agent.tower_link)
         self.mobile_agent.step()
+        a = self.mobile_agent.capture_images([(0,0,3.14)])
+        i = Image.fromarray(a[0], "RGBA")
+        i.save("../thing.png", "PNG")

--- a/simulator/legos.py
+++ b/simulator/legos.py
@@ -39,30 +39,33 @@ class Legos:
         """Returns `__str__` for easy debugging."""
         return str(self)
 
-    def load_lego_urdfs(self, blocks: List[Tuple[float, float, str]]) -> None:
+    def load_lego_urdfs(self, blocks: List[Tuple[int, float]]) -> None:
         """Loads the blocks specified in the list.
         Takes in a list of x and y positions, as well as the rgb color to 
         make the blocks, and loads them upright into the play field. Also 
         does validation to make sure the blocks are in range, and throws an 
         exception if they are not.
 
-        :param blocks: a list of tuples of x, y, and rgb hex
+        :param blocks: a list of tuples of bin-offset values
         :raises ValueError: if the x or y is out of range or hex is invalid
         """
+        BIN_XS = [-0.5461, -0.27305, 0.0, 0.27305, 0.5461]
+        BIN_YBASE = .2667
+        BIN_COLORS = ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff', '#00ffff', '#000000', '#ffffff', '#000000', '#ffffff']
 
         for b in blocks:
-            # For readability
-            b_x = b[0]
-            b_y = b[1]
-            b_z = b[2]
+            # Convert from bin-offset to xyz
+            b_x = BIN_XS[(b[0]-1)%5] # Note one index
+            b_y = (1 if b[0] >= 6 else -1) * (BIN_YBASE + b[1])
+            b_z = .01
 
             # Check that the color is valid with regex
-            if re.match(r"#[0-9a-f]{6}", b[3]) == None:
+            if re.match(r"#[0-9a-f]{6}", BIN_COLORS[b[0]-1]) == None:
                 raise ValueError("Must have valid rgb hex color")
             # Compute its color
             # We hard code the alpha as it must be exactly 0 or 1
             # From stackoverflow.com/questions/29643352/converting-hex-to-rgb-value-in-python
-            b_color = [int(b[3].lstrip('#')[i:i+2], 16) / 256 for i in (0,2,4)] + [1]
+            b_color = [int(BIN_COLORS[b[0]-1].lstrip('#')[i:i+2], 16) / 256 for i in (0,2,4)] + [1]
 
             # Check that it is valid
             # Basic sanity check that it is in bin area for now


### PR DESCRIPTION
Added the function `capture_images`, which takes in a list of poses and outputs a list of images taken by the robot at those poses. The result is a list of `300 x 300 x 4` `numpy` arrays in RGBA format. Transparent pixels are sufficiently far off to not count as part of the arena.

Several notes on this method:
* It used to use the right camera of the old block-stacker. I simply centered the camera.
* More significantly, the robot is usually still visible in the pictures taken. We can make the robot transparent, but not without making it transparent to us. I added optional functionality to make the robot invisible during the method, but it takes time.